### PR TITLE
Add Specialization Grid and Doctor list by Specialty

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,12 +14,12 @@ android {
     ndkVersion = "27.0.12077973"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.toVersion(17)
+        targetCompatibility = JavaVersion.toVersion(17)
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        jvmTarget = JavaVersion.toVersion(17).toString()
     }
 
     defaultConfig {

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../features/doctor_details/ui/doctor_details_screen.dart';
+import '../../features/doctors_by_specialty/ui/doctors_by_specialty_list_screen.dart';
+import '../../features/home/data/models/specializations_response_model.dart';
 import '../../features/home/logic/home_cubit.dart';
 import '../../features/layout/bloc/bottom_navigation_bar_cubit.dart';
 import '../../features/layout/layout_screen.dart';
@@ -64,8 +66,29 @@ class AppRouter {
       case Routes.mapFindNearbyScreen:
         return MaterialPageRoute(builder: (_) => const MapFindNearbyScreen());
       case Routes.specializationsSeeAllGridScreen:
+        if (arguments is List<SpecializationsData>) {
+          return MaterialPageRoute(
+            builder:
+                (_) => SpecializationsSeeAllGridScreen(
+                  specializationsDataList: arguments,
+                ),
+          );
+        }
         return MaterialPageRoute(
-          builder: (_) => const SpecializationsSeeAllGridScreen(),
+          builder:
+              (_) => const SpecializationsSeeAllGridScreen(
+                specializationsDataList: [],
+              ),
+        );
+      case Routes.doctorsBySpecialtyListScreen:
+        if (arguments is List<Doctors>) {
+          return MaterialPageRoute(
+            builder:
+                (_) => DoctorsBySpecialtyListScreen(doctorsList: arguments),
+          );
+        }
+        return MaterialPageRoute(
+          builder: (_) => const DoctorsBySpecialtyListScreen(doctorsList: []),
         );
       case Routes.doctorDetailsScreen:
         return MaterialPageRoute(builder: (_) => const DoctorDetailsScreen());

--- a/lib/core/routing/routes.dart
+++ b/lib/core/routing/routes.dart
@@ -8,5 +8,7 @@ class Routes {
   static const String mapFindNearbyScreen = "/mapFindNearbyScreen";
   static const String specializationsSeeAllGridScreen =
       "/specializationsSeeAllGridScreen";
+  static const String doctorsBySpecialtyListScreen =
+      "/doctorsBySpecialtyListScreen";
   static const String doctorDetailsScreen = "/doctorDetailsScreen";
 }

--- a/lib/core/theming/styles.dart
+++ b/lib/core/theming/styles.dart
@@ -59,6 +59,11 @@ class TextStyles {
     fontWeight: FontWeightHelper.bold,
     color: ColorsManager.darkBlue,
   );
+  static TextStyle font14DarkBlueRegular = TextStyle(
+    fontSize: 14.sp,
+    fontWeight: FontWeightHelper.regular,
+    color: ColorsManager.darkBlue,
+  );
   static TextStyle font14DarkBlueMedium = TextStyle(
     fontSize: 14.sp,
     fontWeight: FontWeightHelper.medium,

--- a/lib/features/doctors_by_specialty/ui/doctors_by_specialty_list_screen.dart
+++ b/lib/features/doctors_by_specialty/ui/doctors_by_specialty_list_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../core/widgets/custom_app_bar.dart';
+import '../../home/data/models/specializations_response_model.dart';
+import '../../home/ui/widgets/doctors_list/doctors_list_view_item.dart';
+
+class DoctorsBySpecialtyListScreen extends StatelessWidget {
+  final List<Doctors> doctorsList;
+
+  const DoctorsBySpecialtyListScreen({super.key, required this.doctorsList});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Padding(
+        padding: EdgeInsets.only(top: 60.h, right: 16.w, left: 16.w),
+        child: Column(
+          children: [
+            CustomAppBar(title: "Doctor"),
+            Expanded(
+              child: ListView.builder(
+                itemCount: doctorsList.length,
+                itemBuilder: (context, index) {
+                  return DoctorsListViewItem(doctorsModel: doctorsList[index]);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/ui/widgets/doctors_speciality_see_all.dart
+++ b/lib/features/home/ui/widgets/doctors_speciality_see_all.dart
@@ -1,8 +1,11 @@
 import 'package:book_a_doctor/core/helpers/extensions.dart';
 import 'package:book_a_doctor/core/theming/styles.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/routing/routes.dart';
+import '../../data/models/specializations_response_model.dart';
+import '../../logic/home_cubit.dart';
 
 class DoctorsSpecialitySeeAll extends StatelessWidget {
   const DoctorsSpecialitySeeAll({super.key});
@@ -15,7 +18,18 @@ class DoctorsSpecialitySeeAll extends StatelessWidget {
         const Spacer(),
         TextButton(
           onPressed: () {
-            context.pushNamed(Routes.specializationsSeeAllGridScreen);
+            final specializationsList =
+                context
+                    .read<HomeCubit>()
+                    .specializationsList
+                    ?.whereType<SpecializationsData>()
+                    .toList() ??
+                [];
+
+            context.pushNamed(
+              Routes.specializationsSeeAllGridScreen,
+              arguments: specializationsList,
+            );
           },
           child: Text("See All", style: TextStyles.font12BlueRegular),
         ),

--- a/lib/features/specializations/ui/specializations_see_all_grid_screen.dart
+++ b/lib/features/specializations/ui/specializations_see_all_grid_screen.dart
@@ -1,17 +1,87 @@
+import 'package:book_a_doctor/core/helpers/extensions.dart';
+import 'package:book_a_doctor/core/helpers/spacing.dart';
+import 'package:book_a_doctor/core/theming/styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/svg.dart';
 
+import '../../../core/routing/routes.dart';
+import '../../../core/theming/colors.dart';
 import '../../../core/widgets/custom_app_bar.dart';
+import '../../home/data/models/specializations_response_model.dart';
 
 class SpecializationsSeeAllGridScreen extends StatelessWidget {
-  const SpecializationsSeeAllGridScreen({super.key});
+  final List<SpecializationsData> specializationsDataList;
+
+  const SpecializationsSeeAllGridScreen({
+    super.key,
+    required this.specializationsDataList,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Padding(
         padding: EdgeInsets.only(top: 60.h, right: 16.w, left: 16.w),
-        child: Column(children: [CustomAppBar(title: "Doctor Speciality")]),
+        child: Column(
+          children: [
+            CustomAppBar(title: "Doctor Speciality"),
+            verticalSpace(42),
+            Expanded(
+              child: GridView.builder(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount:
+                      MediaQuery.of(context).size.width > 600
+                          ? 4
+                          : 3, // count of columns
+                  crossAxisSpacing: 32, //  spacing between columns
+                  mainAxisSpacing: 36, // spacing between rows
+                  childAspectRatio: 0.7,
+                ),
+                itemBuilder: (BuildContext context, int index) {
+                  final specialization = specializationsDataList[index];
+                  return InkWell(
+                    borderRadius: BorderRadius.circular(28.r),
+                    onTap: () {
+                      final doctorsForSpecialization =
+                          specialization.doctorsList
+                              ?.whereType<Doctors>()
+                              .toList() ??
+                          [];
+
+                      context.pushNamed(
+                        Routes.doctorsBySpecialtyListScreen,
+                        arguments: doctorsForSpecialization,
+                      );
+                    },
+                    child: Column(
+                      children: [
+                        CircleAvatar(
+                          radius: 40.r,
+                          backgroundColor: ColorsManager.lightBlue,
+                          child: SvgPicture.asset(
+                            'assets/svgs/general_speciality.svg',
+                            height: 40.h,
+                            width: 40.w,
+                          ),
+                        ),
+                        verticalSpace(12),
+                        Text(
+                          specialization.name ?? 'Specialization',
+                          style: TextStyles.font14DarkBlueRegular,
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    ),
+                  );
+                },
+                itemCount: specializationsDataList.length,
+                padding: EdgeInsets.all(10),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
- Displayed a GridView of medical specializations on the "SpecializationsSeeAllGridScreen".
- On tapping a specialization, navigated to a new screen ("DoctorDetailsScreen") which shows a list of doctors related to the selected specialization.
- Created a placeholder screen ("DoctorDetailsScreen") for displaying detailed information about a selected doctor.
- Updated the AppRouter to support routing with arguments.

![Screenshot_20250709_131410](https://github.com/user-attachments/assets/06be9408-bd09-484c-ba65-50cd5ae16969)
![Screenshot_20250709_131422](https://github.com/user-attachments/assets/b1c46bc9-0a34-4fb1-a408-c187cdc9c569)
